### PR TITLE
Fixed local_data::Key issue

### DIFF
--- a/src/colorize.rs
+++ b/src/colorize.rs
@@ -129,13 +129,11 @@ impl BgColor {
 }
 
 mod internal {
-    use std::local_data;
     use super::{Color, BgColor};
 
     static DEFAULT_FG: int = 39;
     static DEFAULT_BG: int = 49;
-
-    static glob_color: local_data::Key<GlobalColor> = &local_data::Key;
+    local_data_key!(glob_color: GlobalColor)
 
     pub trait TermAttrib {
         fn to_int(&self) -> int;


### PR DESCRIPTION
- On the latest nightly, the build was failing because of deprecated Key instantiation. 

```
   Compiling colorize v0.0.1 (https://github.com/jeremyletang/colorize.git#ref=ab5f038c641230ea241b6d2410062e8b22693f6d)
Could not execute process `rustc src/colorize.rs --crate-name colorize --crate-type rlib --crate-type dylib -g -C metadata=colorize:-:0.0.1:-:https://github.com/jeremyletang/colorize.git#ref=ab5f038c641230ea241b6d2410062e8b22693f6d -C extra-filename=8c2764ab94add3b2 --out-dir /home/travis/build/rgawdzik/cs246test/target/deps -L /home/travis/build/rgawdzik/cs246test/target/deps -L /home/travis/build/rgawdzik/cs246test/target/deps` (status=101)
--- stderr
src/colorize.rs:138:56: 138:71 error: unresolved name `local_data::Key`.
src/colorize.rs:138     static glob_color: local_data::Key<GlobalColor> = &local_data::Key;
                                                                           ^~~~~~~~~~~~~~~
error: aborting due to previous error
```
